### PR TITLE
fix max packet size since encryption adds some data

### DIFF
--- a/Assets/MonkeTransport/Monke.cs
+++ b/Assets/MonkeTransport/Monke.cs
@@ -36,7 +36,7 @@ public class Monke : Transport
 #else
     public override bool ServerDisconnect(int connectionId) => CommunicationTransport.ServerDisconnect(connectionId);
 #endif
-    public override int GetMaxPacketSize(int channelId = 0) => CommunicationTransport.GetMaxPacketSize(channelId);
+    public override int GetMaxPacketSize(int channelId = 0) => CommunicationTransport.GetMaxPacketSize(channelId) - 64;
     public override void ServerEarlyUpdate() => CommunicationTransport.ServerEarlyUpdate();
     public override void ClientEarlyUpdate() => CommunicationTransport.ClientEarlyUpdate();
     public override void ClientDisconnect() => CommunicationTransport.ClientDisconnect();


### PR DESCRIPTION
When mirror batches packets up to max packet size, monke will exceed the underlying transport's maximum packet size because encryption adds a few bytes to it.
This was reported to the orginal project in https://github.com/cxxpxr/monke/issues/2 , but 16 bytes was not enough according to my tests. 64 seems to fix the issues with batching and exceeding the maximum packet size.

EDIT: I've tested this with the kcp9k and multiplex transports.